### PR TITLE
ci: fix Python test by using a non-structural resource

### DIFF
--- a/examples/py-acl/__main__.py
+++ b/examples/py-acl/__main__.py
@@ -1,14 +1,5 @@
 """A Python Pulumi program"""
 
-import json
 import pulumi_tailscale as tailscale
 
-acl = tailscale.Acl("demo-py",
-                    acl=json.dumps({
-                        "ACLs": [{
-                            "action": "accept",
-                            "users": ["*"],
-                            "ports": ["*:*"],
-                        }]
-                    }))
-
+tailscale.TailnetKey("demo-py")


### PR DESCRIPTION
Fixes #98

The ACL resource is what Pulumi would consider a "structural resource", see:
- https://github.com/pulumi/pulumi/issues/918

This kind of resource is not quite correctly handled in the object model, and this interacts poorly with the upstream provider requiring the ACL to exactly match the default for "create" to succeed.

It's a reasonable safety precaution of the upstream provider, so it's better to work around that by using a regular resource in the test.