### PR TITLE
Correct the apikey key for the pulumi provider docs example

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -17,86 +17,98 @@ The Tailscale provider is available as a package in all Pulumi languages:
 
 {{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 {{% choosable language typescript %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: nodejs
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: python
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}
 {{% choosable language csharp %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: dotnet
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: go
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}
 {{% choosable language yaml %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: yaml
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}
 {{% choosable language java %}}
+```
+pulumi config set tailscale:apiKey tskey-1234567CNTRL-abcdefghijklmnopqrstu --secret
+pulumi config set tailscale:tailnet example.com
+```
+
 ```yaml
 # Pulumi.yaml provider configuration file
 name: configuration-example
 runtime: java
 config:
-    tailscale:apiKey:
-        value: 12345
-    tailscale:tailnet:
-        value: example.com
-
+    tailscale:apiKey: tskey-1234567CNTRL-abcdefghijklmnopqrstu
+    tailscale:tailnet: example.com
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
This updates the pulumi registry package docs (https://www.pulumi.com/registry/packages/tailscale/installation-configuration/) to match: https://tailscale.com/kb/1211/pulumi-provider

Currently it says to use tailscale:apiKey.value where .value is a key under tailscale:apiKey which does not work